### PR TITLE
Multiply a matrix with Point/Vector

### DIFF
--- a/rust/src/coordinate.rs
+++ b/rust/src/coordinate.rs
@@ -1,3 +1,5 @@
+use std::ops::{Index, IndexMut};
+
 // These really ought to be enums and probably mean we don't need `w`, but we'll see how it pans
 // out in the book.
 #[allow(dead_code)]
@@ -23,6 +25,10 @@ impl Point {
             z,
             w: POINT_MAGIC,
         }
+    }
+
+    pub fn len(&self) -> usize {
+        4
     }
 }
 
@@ -90,6 +96,74 @@ fn cross(a: &Vector, b: &Vector) -> Vector {
     )
 }
 
+// TODO A macro could easily impl Vector and Point here.
+impl Index<usize> for Vector {
+    type Output = f64;
+
+    fn index(&self, ix: usize) -> &f64 {
+        match ix {
+            0 => &self.x,
+            1 => &self.y,
+            2 => &self.z,
+            3 => &self.w,
+            _ => panic!(format!(
+                "index out of bounds: the len is 4 but the index is {}",
+                ix
+            )),
+        }
+    }
+}
+
+// TODO A macro could easily impl Vector and Point here.
+impl IndexMut<usize> for Vector {
+    fn index_mut(&mut self, ix: usize) -> &mut f64 {
+        match ix {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            2 => &mut self.z,
+            3 => &mut self.w,
+            _ => panic!(format!(
+                "index out of bounds: the len is 4 but the index is {}",
+                ix
+            )),
+        }
+    }
+}
+
+// TODO A macro could easily impl Vector and Point here.
+impl Index<usize> for Point {
+    type Output = f64;
+
+    fn index(&self, ix: usize) -> &f64 {
+        match ix {
+            0 => &self.x,
+            1 => &self.y,
+            2 => &self.z,
+            3 => &self.w,
+            _ => panic!(format!(
+                "index out of bounds: the len is 4 but the index is {}",
+                ix
+            )),
+        }
+    }
+}
+
+// TODO A macro could easily impl Vector and Point here.
+impl IndexMut<usize> for Point {
+    fn index_mut(&mut self, ix: usize) -> &mut f64 {
+        match ix {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            2 => &mut self.z,
+            3 => &mut self.w,
+            _ => panic!(format!(
+                "index out of bounds: the len is 4 but the index is {}",
+                ix
+            )),
+        }
+    }
+}
+
 #[allow(dead_code)]
 impl Vector {
     pub fn new(x: f64, y: f64, z: f64) -> Self {
@@ -115,6 +189,10 @@ impl Vector {
 
     pub fn cross(&self, rhs: &Self) -> Self {
         cross(self, rhs)
+    }
+
+    pub fn len(&self) -> usize {
+        4
     }
 }
 
@@ -679,5 +757,35 @@ mod test {
         let exp2 = Vector::new(1.0, -2.0, 1.0);
         assert_eq!(a.cross(&b), exp1);
         assert_eq!(b.cross(&a), exp2);
+    }
+
+    #[test]
+    fn vectors_can_be_indexed() {
+        let a = Vector::new(1.0, 2.0, 3.0);
+        assert_eq!(a[0], 1.0);
+        assert_eq!(a[1], 2.0);
+        assert_eq!(a[2], 3.0);
+        assert_eq!(a[3], 0.0);
+    }
+
+    #[test]
+    fn points_can_be_indexed() {
+        let a = Point::new(1.0, 2.0, 3.0);
+        assert_eq!(a[0], 1.0);
+        assert_eq!(a[1], 2.0);
+        assert_eq!(a[2], 3.0);
+        assert_eq!(a[3], 1.0);
+    }
+
+    #[test]
+    fn points_have_a_length() {
+        let a = Point::new(1.0, 2.0, 3.0);
+        assert_eq!(a.len(), 4);
+    }
+
+    #[test]
+    fn vectors_have_a_length() {
+        let a = Vector::new(1.0, 2.0, 3.0);
+        assert_eq!(a.len(), 4);
     }
 }

--- a/rust/src/matrix.rs
+++ b/rust/src/matrix.rs
@@ -1,3 +1,4 @@
+use crate::coordinate::{Point, Vector};
 use smallvec::*;
 use std::cmp::PartialEq;
 use std::ops::{Index, IndexMut, Mul};
@@ -260,9 +261,41 @@ impl Mul for Matrix {
     }
 }
 
+impl Mul<Vector> for Matrix {
+    type Output = Vector;
+
+    fn mul(self, rhs: Self::Output) -> Self::Output {
+        assert!(self.dims.1 == rhs.len());
+        let mut v = Vector::new(0., 0., 0.);
+        for row in 0..self.dims.0 {
+            for col in 0..self.dims.1 {
+                v[row] += rhs[col] * self[(row, col)];
+            }
+        }
+        v
+    }
+}
+
+impl Mul<Point> for Matrix {
+    type Output = Point;
+
+    fn mul(self, rhs: Self::Output) -> Self::Output {
+        assert!(self.dims.1 == rhs.len());
+        let mut p = Point::new(0., 0., 0.);
+        for row in 0..self.dims.0 {
+            for col in 0..self.dims.1 {
+                p[row] += rhs[col] * self[(row, col)];
+            }
+        }
+        p.w = 1.0;
+        p
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::coordinate::*;
 
     #[test]
     fn constructing_and_inspecting_a_4x4_matrix() {
@@ -826,5 +859,37 @@ mod test {
 
         let c = a.clone() * b.clone();
         assert_eq!(c * b.inverse(), a);
+    }
+
+    #[test]
+    fn a_matrix_multiplied_by_a_point() {
+        #[rustfmt::skip]
+        let m: Matrix = SquareMatrix::from_nested_vec(vec![
+            vec![1., 2., 3., 4.],
+            vec![2., 4., 4., 2.],
+            vec![8., 6., 4., 1.],
+            vec![0., 0., 0., 1.],
+        ]);
+
+        #[rustfmt::skip]
+        let b = Point::new(1., 2., 3.);
+
+        assert_eq!(m * b, Point::new(18., 24., 33.));
+    }
+
+    #[test]
+    fn a_matrix_multiplied_by_a_vector() {
+        #[rustfmt::skip]
+        let m: Matrix = SquareMatrix::from_nested_vec(vec![
+            vec![1., 2., 3., 4.],
+            vec![2., 4., 4., 2.],
+            vec![8., 6., 4., 1.],
+            vec![0., 0., 0., 1.],
+        ]);
+
+        #[rustfmt::skip]
+        let b = Vector::new(1., 2., 3.);
+
+        assert_eq!(m * b, Vector::new(14., 22., 32.));
     }
 }


### PR DESCRIPTION
Technically the example in the book is working on a `tuple` but I don't really have an implementation for that. It seems like there is no flexibility in changing `w` for Vectors and Points but tuple's can have their `w`s changed just fine. It's a bit mixed from what I've seen, though, so I'm not sure about that rule.